### PR TITLE
override control host and port if envs are present

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -104,7 +104,9 @@ changestream {
 
   // Http status and control server
   control.host = 127.0.0.1
+  control.host = $(?CONTROL_HOST)
   control.port = 9521
+  control.port = $(?CONTROL_PORT)
 }
 
 akka {

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -104,9 +104,9 @@ changestream {
 
   // Http status and control server
   control.host = 127.0.0.1
-  control.host = $(?CONTROL_HOST)
+  control.host = ${?CONTROL_HOST}
   control.port = 9521
-  control.port = $(?CONTROL_PORT)
+  control.port = ${?CONTROL_PORT}
 }
 
 akka {


### PR DESCRIPTION
@racerpeter 
This allows for overriding of the default `control.host` and `control.port` with an env