### PR TITLE
New transaction actor strategy

### DIFF
--- a/circle.mycnf.sh
+++ b/circle.mycnf.sh
@@ -2,3 +2,5 @@
 
 [ "$CIRCLE_NODE_INDEX" == "0" ] && sudo cp -f src/test/resources/my.cnf /etc/my.cnf
 [ "$CIRCLE_NODE_INDEX" == "1" ] && sudo cp -f src/test/resources/my-gtid.cnf /etc/my.cnf
+
+exit 0

--- a/circle.mycnf.sh
+++ b/circle.mycnf.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-[ "$CIRCLE_NODE_INDEX" == "0" ] && sudo mv src/test/resources/my.cnf /etc/my.cnf
-[ "$CIRCLE_NODE_INDEX" == "1" ] && sudo mv src/test/resources/my-gtid.cnf /etc/my.cnf
+[ "$CIRCLE_NODE_INDEX" == "0" ] && sudo cp -f src/test/resources/my.cnf /etc/my.cnf
+[ "$CIRCLE_NODE_INDEX" == "1" ] && sudo cp -f src/test/resources/my-gtid.cnf /etc/my.cnf

--- a/circle.mycnf.sh
+++ b/circle.mycnf.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+[ "$CIRCLE_NODE_INDEX" == "0" ] && sudo mv src/test/resources/my.cnf /etc/my.cnf
+[ "$CIRCLE_NODE_INDEX" == "1" ] && sudo mv src/test/resources/my-gtid.cnf /etc/my.cnf

--- a/circle.yml
+++ b/circle.yml
@@ -24,7 +24,8 @@ dependencies:
     - sbt sbt-version
     # Configure MySQL
     - mysql -e "CREATE USER 'changestream'@'localhost' IDENTIFIED BY 'changestreampass';GRANT REPLICATION SLAVE ON *.* TO 'changestream'@'localhost';GRANT ALL ON *.* TO 'changestream'@'localhost';" -uroot;
-    - case $CIRCLE_NODE_INDEX in 0) sudo mv src/test/resources/my.cnf /etc/my.cnf ;; 1) sudo mv src/test/resources/my-gtid.cnf /etc/my.cnf ;; esac
+    - [ "$CIRCLE_NODE_INDEX" == "0" ] && sudo mv src/test/resources/my.cnf /etc/my.cnf
+    - [ "$CIRCLE_NODE_INDEX" == "1" ] && sudo mv src/test/resources/my-gtid.cnf /etc/my.cnf
     - sudo service mysql restart
     - cat /etc/my.cnf
     - echo "show variables like 'gtid_mode';" | mysql -uroot

--- a/circle.yml
+++ b/circle.yml
@@ -24,7 +24,7 @@ dependencies:
     - sbt sbt-version
     # Configure MySQL
     - mysql -e "CREATE USER 'changestream'@'localhost' IDENTIFIED BY 'changestreampass';GRANT REPLICATION SLAVE ON *.* TO 'changestream'@'localhost';GRANT ALL ON *.* TO 'changestream'@'localhost';" -uroot;
-    - case $CIRCLE_NODE_INDEX in 0) MY_CNF="my.cnf" ;; 1) MY_CNF="my-gtid.cnf" ;; esac; sudo mv src/test/resources/$MY_CNF /etc/my.cnf
+    - case $CIRCLE_NODE_INDEX in 0) MY_CNF="my.cnf" ;; 1) MY_CNF="my-gtid.cnf" ;; esac; echo $MY_CNF; sudo mv src/test/resources/$MY_CNF /etc/my.cnf
     - sudo service mysql restart
     - cat /etc/my.cnf
     - echo "show variables like 'gtid_mode';" | mysql -uroot

--- a/circle.yml
+++ b/circle.yml
@@ -24,8 +24,7 @@ dependencies:
     - sbt sbt-version
     # Configure MySQL
     - mysql -e "CREATE USER 'changestream'@'localhost' IDENTIFIED BY 'changestreampass';GRANT REPLICATION SLAVE ON *.* TO 'changestream'@'localhost';GRANT ALL ON *.* TO 'changestream'@'localhost';" -uroot;
-    - chmod u+x circle.mycnf.sh
-    - ./circle.mycnf.sh
+    - chmod +x *.sh && ./circle.mycnf.sh
     - sudo service mysql restart
     - cat /etc/my.cnf
     - echo "show variables like 'gtid_mode';" | mysql -uroot

--- a/circle.yml
+++ b/circle.yml
@@ -24,7 +24,7 @@ dependencies:
     - sbt sbt-version
     # Configure MySQL
     - mysql -e "CREATE USER 'changestream'@'localhost' IDENTIFIED BY 'changestreampass';GRANT REPLICATION SLAVE ON *.* TO 'changestream'@'localhost';GRANT ALL ON *.* TO 'changestream'@'localhost';" -uroot;
-    - case $CIRCLE_NODE_INDEX in 0) MY_CNF="my.cnf" ;; 1) MY_CNF="my-gtid.cnf" ;; esac; echo $MY_CNF; sudo mv src/test/resources/$MY_CNF /etc/my.cnf
+    - case $CIRCLE_NODE_INDEX in 0) sudo mv src/test/resources/my.cnf /etc/my.cnf ;; 1) sudo mv src/test/resources/my-gtid.cnf /etc/my.cnf ;; esac
     - sudo service mysql restart
     - cat /etc/my.cnf
     - echo "show variables like 'gtid_mode';" | mysql -uroot

--- a/circle.yml
+++ b/circle.yml
@@ -24,8 +24,7 @@ dependencies:
     - sbt sbt-version
     # Configure MySQL
     - mysql -e "CREATE USER 'changestream'@'localhost' IDENTIFIED BY 'changestreampass';GRANT REPLICATION SLAVE ON *.* TO 'changestream'@'localhost';GRANT ALL ON *.* TO 'changestream'@'localhost';" -uroot;
-    - [ "$CIRCLE_NODE_INDEX" == "0" ] && sudo mv src/test/resources/my.cnf /etc/my.cnf
-    - [ "$CIRCLE_NODE_INDEX" == "1" ] && sudo mv src/test/resources/my-gtid.cnf /etc/my.cnf
+    - chmod +x *.sh && ./circle.mycnf.sh
     - sudo service mysql restart
     - cat /etc/my.cnf
     - echo "show variables like 'gtid_mode';" | mysql -uroot

--- a/circle.yml
+++ b/circle.yml
@@ -24,7 +24,7 @@ dependencies:
     - sbt sbt-version
     # Configure MySQL
     - mysql -e "CREATE USER 'changestream'@'localhost' IDENTIFIED BY 'changestreampass';GRANT REPLICATION SLAVE ON *.* TO 'changestream'@'localhost';GRANT ALL ON *.* TO 'changestream'@'localhost';" -uroot;
-    - chmod +x *.sh && ./circle.mycnf.sh
+    - chmod +x circle.mycnf.sh && ./circle.mycnf.sh
     - sudo service mysql restart
     - cat /etc/my.cnf
     - echo "show variables like 'gtid_mode';" | mysql -uroot

--- a/circle.yml
+++ b/circle.yml
@@ -20,11 +20,12 @@ dependencies:
     - wget --no-clobber --output-document=$HOME/sbt/sbt-launch-"$SBT_VERSION.jar" https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/"$SBT_VERSION"/sbt-launch.jar || true
     - echo "java $SBT_OPTS -jar $HOME/sbt/sbt-launch-$SBT_VERSION.jar \"\$@\"" > $HOME/bin/sbt
     - chmod u+x $HOME/bin/sbt
-    -  which sbt
+    - which sbt
     - sbt sbt-version
     # Configure MySQL
     - mysql -e "CREATE USER 'changestream'@'localhost' IDENTIFIED BY 'changestreampass';GRANT REPLICATION SLAVE ON *.* TO 'changestream'@'localhost';GRANT ALL ON *.* TO 'changestream'@'localhost';" -uroot;
-    - chmod +x circle.mycnf.sh && ./circle.mycnf.sh
+    - chmod u+x circle.mycnf.sh
+    - ./circle.mycnf.sh
     - sudo service mysql restart
     - cat /etc/my.cnf
     - echo "show variables like 'gtid_mode';" | mysql -uroot

--- a/src/main/scala/changestream/actors/JsonFormatterActor.scala
+++ b/src/main/scala/changestream/actors/JsonFormatterActor.scala
@@ -176,12 +176,15 @@ class JsonFormatterActor (
   protected def transactionInfo(message: MutationWithInfo): ListMap[String, JsValue] = {
     message.transaction match {
       case Some(txn) => ListMap(
-        "transaction" -> JsObject(
+        "transaction" -> JsObject(ListMap(
           "id" -> txn.gtid.toJson,
           "row_count" -> txn.rowCount.toJson
-        )
-      )
-      case None => ListMap.empty[String, JsValue]
+        ) ++ (txn.lastMutationInTransaction match {
+          case true => ListMap("last_mutation" -> JsTrue)
+          case false => ListMap.empty
+        })
+      ))
+      case None => ListMap.empty
     }
   }
 
@@ -209,11 +212,11 @@ class JsonFormatterActor (
 
   protected def getJsonRowData(rowData: ListMap[String, JsValue]): ListMap[String, JsValue] = includeData match {
     case true => ListMap("row_data" -> JsObject(rowData))
-    case false => ListMap.empty[String, JsValue]
+    case false => ListMap.empty
   }
 
   protected def updateInfo(oldRowData: Option[ListMap[String, JsValue]]): ListMap[String, JsValue] = includeData match {
-    case true => oldRowData.map({ row => ListMap("old_row_data" -> JsObject(row)) }).getOrElse(ListMap.empty[String, JsValue])
-    case false => ListMap.empty[String, JsValue]
+    case true => oldRowData.map({ row => ListMap("old_row_data" -> JsObject(row)) }).getOrElse(ListMap.empty)
+    case false => ListMap.empty
   }
 }

--- a/src/main/scala/changestream/actors/JsonFormatterActor.scala
+++ b/src/main/scala/changestream/actors/JsonFormatterActor.scala
@@ -177,7 +177,7 @@ class JsonFormatterActor (
     message.transaction match {
       case Some(txn) => ListMap(
         "transaction" -> JsObject(
-          "id" -> txn.guid.toJson,
+          "id" -> txn.gtid.toJson,
           "row_count" -> txn.rowCount.toJson
         )
       )

--- a/src/main/scala/changestream/actors/TransactionActor.scala
+++ b/src/main/scala/changestream/actors/TransactionActor.scala
@@ -36,18 +36,14 @@ class TransactionActor(getNextHop: ActorRefFactory => ActorRef) extends Actor {
       log.debug(s"Received GTID for transaction: ${guid}")
       setState(info = Some(TransactionInfo(guid)))
 
-    case CommitTransaction =>
-      log.debug(s"Received CommitTransacton")
+    case _: TransactionEvent =>
+      log.debug(s"Received Commit/Rollback")
       previousMutation.foreach { mutation =>
         log.debug(s"Adding transaction info and forwarding to the ${nextHop.path.name} actor")
         nextHop ! mutation.copy(transaction = transactionInfo.map { info =>
           info.copy(rowCount = mutationCount,lastMutationInTransaction = true)
         })
       }
-      setState(info = None, prev = None)
-
-    case RollbackTransaction =>
-      log.debug(s"Received RollbackTransacton")
       setState(info = None, prev = None)
 
     case event: MutationWithInfo =>

--- a/src/main/scala/changestream/events/ChangeEvent.scala
+++ b/src/main/scala/changestream/events/ChangeEvent.scala
@@ -109,10 +109,10 @@ case class Delete(
 
 /** Container for information about a mutation's transaction.
   *
-  * @param guid The unique identifier for the transaction
+  * @param gtid The unique identifier for the transaction
   * @param rowCount The number of rows affected by this transaction
   */
-case class TransactionInfo(guid: String, rowCount: Long)
+case class TransactionInfo(gtid: String, rowCount: Long, lastMutationInTransaction: Boolean = false)
 
 /** Container for a table's column information.
   *

--- a/src/main/scala/changestream/events/ChangeEvent.scala
+++ b/src/main/scala/changestream/events/ChangeEvent.scala
@@ -112,7 +112,7 @@ case class Delete(
   * @param gtid The unique identifier for the transaction
   * @param rowCount The number of rows affected by this transaction
   */
-case class TransactionInfo(gtid: String, rowCount: Long, lastMutationInTransaction: Boolean = false)
+case class TransactionInfo(gtid: String, rowCount: Long = 0, lastMutationInTransaction: Boolean = false)
 
 /** Container for a table's column information.
   *

--- a/src/test/scala/changestream/actors/JsonFormatterActorSpec.scala
+++ b/src/test/scala/changestream/actors/JsonFormatterActorSpec.scala
@@ -108,19 +108,19 @@ class JsonFormatterActorSpec extends Base with Config {
       txJson("id").toString(jsStringPrinter) should fullyMatch regex "(?i)([0-9a-fA-F]){8}-([0-9a-fA-F]){4}-([0-9a-fA-F]){4}-([0-9a-fA-F]){4}-([0-9a-fA-F]){12}(:\\d+)?"
     }
 
-    "have valid transaction row_count" in {
-      json should contain key "transaction"
-      val txJson = getJsFields(json("transaction"))
-      val rowCountCheck = txJson("row_count") match {
-        case JsNumber(num) if (num >= 1) =>
-          "valid number"
-        case _ =>
-          "invalid"
-      }
-      rowCountCheck should be("valid number")
-    }
-
     if(isLastMutationInTransaction) {
+      "have valid transaction row_count" in {
+        json should contain key "transaction"
+        val txJson = getJsFields(json("transaction"))
+        val rowCountCheck = txJson("row_count") match {
+          case JsNumber(num) if (num >= 1) =>
+            "valid number"
+          case _ =>
+            "invalid"
+        }
+        rowCountCheck should be("valid number")
+      }
+
       "have the last mutation flag" in {
         val txJson = getJsFields(json("transaction"))
         txJson should contain key "last_mutation"
@@ -135,6 +135,9 @@ class JsonFormatterActorSpec extends Base with Config {
       }
     }
     else {
+      "not have the row_count flag" in {
+        getJsFields(json("transaction")) shouldNot contain key "row_count"
+      }
       "not have the last mutation flag" in {
         getJsFields(json("transaction")) shouldNot contain key "last_mutation"
       }
@@ -292,7 +295,7 @@ class JsonFormatterActorSpec extends Base with Config {
       crudAllChecksOut(inTransaction = true, rowCount, transactionCount)
     }
     "for the last mutation in a transaction" should {
-      crudAllChecksOut(inTransaction = true, rowCount = 3, transactionRowCount = 3, isLastMutationInTransaction = true)
+      crudAllChecksOut(inTransaction = true, rowCount = 1, transactionRowCount = 1, isLastMutationInTransaction = true)
     }
   }
 

--- a/src/test/scala/changestream/actors/TransactionActorSpec.scala
+++ b/src/test/scala/changestream/actors/TransactionActorSpec.scala
@@ -71,7 +71,16 @@ class TransactionActorSpec extends Base {
       transactionActor ! BeginTransaction
       transactionActor ! mutationFirstInput
       transactionActor ! RollbackTransaction
-      expectNoMsg
+      /**
+        * Modifications to nontransactional tables cannot be rolled back.
+        * If a transaction that is rolled back includes modifications to
+        * nontransactional tables, the entire transaction is logged with
+        * a ROLLBACK statement at the end to ensure that the modifications
+        * to those tables are replicated.
+        *
+        * http://dev.mysql.com/doc/refman/5.7/en/binary-log.html
+        */
+      probe.receiveN(1)
 
       transactionActor ! mutationNextInput
       expectMessageFuzzyGuidMatch(mutationNextInput)

--- a/src/test/scala/changestream/actors/TransactionActorSpec.scala
+++ b/src/test/scala/changestream/actors/TransactionActorSpec.scala
@@ -13,9 +13,9 @@ class TransactionActorSpec extends Base {
 
   val GUID_LENGTH = 36
   val (mutationNoTransaction, _, _) = Fixtures.mutationWithInfo("insert", rowCount = 1, transactionInfo = false, columns = false)
-  val (mutationFirstOutput, _, _) = Fixtures.mutationWithInfo("insert", rowCount = 1, rowInTransaction = 1, transactionInfo = true, isLastChangeInTransaction = false, columns = false)
-  val (mutationNextOutput, _, _) = Fixtures.mutationWithInfo("insert", rowCount = 1, rowInTransaction = 2, transactionInfo = true, isLastChangeInTransaction = false, columns = false)
-  val (mutationLastOutput, _, _) = Fixtures.mutationWithInfo("insert", rowCount = 1, rowInTransaction = 3, transactionInfo = true, isLastChangeInTransaction = true, columns = false)
+  val (mutationFirstOutput, _, _) = Fixtures.mutationWithInfo("insert", rowCount = 1, rowsInTransaction = 1, transactionInfo = true, isLastChangeInTransaction = false, columns = false)
+  val (mutationNextOutput, _, _) = Fixtures.mutationWithInfo("insert", rowCount = 1, rowsInTransaction = 2, transactionInfo = true, isLastChangeInTransaction = false, columns = false)
+  val (mutationLastOutput, _, _) = Fixtures.mutationWithInfo("insert", rowCount = 1, rowsInTransaction = 3, transactionInfo = true, isLastChangeInTransaction = true, columns = false)
   val mutationFirstInput = mutationFirstOutput.copy(transaction = None)
   val mutationNextInput = mutationNextOutput.copy(transaction = None)
   val mutationLastInput = mutationLastOutput.copy(transaction = None)
@@ -25,10 +25,6 @@ class TransactionActorSpec extends Base {
     val msg = probe.expectMsgType[MutationWithInfo]
     val expectObj = mutation.copy(transaction = mutation.transaction.map(info => info.copy(gtid = msg.transaction.get.gtid)))
     msg should be(expectObj)
-  }
-
-  after {
-    transactionActor ! RollbackTransaction
   }
 
   "When receiving a TransactionEvent" should {
@@ -104,7 +100,8 @@ class TransactionActorSpec extends Base {
       inside(m1.transaction) { case Some(info1) =>
         inside(m2.transaction) { case Some(info2) =>
           info1.gtid should be(info2.gtid)
-          info1.rowCount should be(info2.rowCount - 1)
+          info1.rowCount should be(0)
+          info2.rowCount should be(2)
           info1.lastMutationInTransaction should be(false)
           info2.lastMutationInTransaction should be(true)
         }

--- a/src/test/scala/changestream/helpers/Fixtures.scala
+++ b/src/test/scala/changestream/helpers/Fixtures.scala
@@ -97,7 +97,7 @@ object Fixtures {
   def mutation(
                 mutationType: String,
                 rowCount: Int = 1,
-                rowInTransaction: Int = 1,
+                rowsInTransaction: Int = 1,
                 sequenceNext: Long = 0,
                 database: String = "changestream_test",
                 tableName: String = "users",
@@ -145,27 +145,27 @@ object Fixtures {
     }).toArray
   }
 
-  def transactionInfo(rowInTransaction: Int = 1, isLastChangeInTransaction: Boolean = false) =
+  def transactionInfo(rowsInTransaction: Int = 1, isLastChangeInTransaction: Boolean = false) =
     TransactionInfo(
       java.util.UUID.randomUUID().toString,
-      rowInTransaction,
+      isLastChangeInTransaction match { case true => rowsInTransaction case false => 0 },
       isLastChangeInTransaction
     )
-  def transactionInfoGtid(rowInTransaction: Int = 1, isLastChangeInTransaction: Boolean = false) =
+  def transactionInfoGtid(rowsInTransaction: Int = 1, isLastChangeInTransaction: Boolean = false) =
     TransactionInfo(
       s"${java.util.UUID.randomUUID().toString}:${Random.nextInt(100000)}",
-      rowInTransaction,
+      isLastChangeInTransaction match { case true => rowsInTransaction case false => 0 },
       isLastChangeInTransaction
     )
-  def transactionInfoEither(rowInTransaction: Int = 1, isLastChangeInTransaction: Boolean = false) = Random.nextInt(2) match {
-    case 0 => transactionInfo(rowInTransaction, isLastChangeInTransaction)
-    case 1 => transactionInfoGtid(rowInTransaction, isLastChangeInTransaction)
+  def transactionInfoEither(rowsInTransaction: Int = 1, isLastChangeInTransaction: Boolean = false) = Random.nextInt(2) match {
+    case 0 => transactionInfo(rowsInTransaction, isLastChangeInTransaction)
+    case 1 => transactionInfoGtid(rowsInTransaction, isLastChangeInTransaction)
   }
 
   def mutationWithInfo(
                         mutationType: String,
                         rowCount: Int = 1,
-                        rowInTransaction: Int = 1,
+                        rowsInTransaction: Int = 1,
                         transactionInfo: Boolean = true,
                         columns: Boolean = true,
                         sequenceNext: Long = 0,
@@ -174,11 +174,11 @@ object Fixtures {
                         tableId: Int = 123,
                         isLastChangeInTransaction: Boolean = false
                       ): (MutationWithInfo, Seq[ListMap[String, Any]], Seq[ListMap[String, Any]]) = {
-    val (m, d, od) = mutation(mutationType, rowCount, rowInTransaction, sequenceNext, database, tableName, tableId)
+    val (m, d, od) = mutation(mutationType, rowCount, rowsInTransaction, sequenceNext, database, tableName, tableId)
     (MutationWithInfo(
       m,
       transaction = transactionInfo match {
-        case true => Some(transactionInfoEither(rowInTransaction, isLastChangeInTransaction))
+        case true => Some(transactionInfoEither(rowsInTransaction, isLastChangeInTransaction))
         case false => None
       },
       columns = columns match {

--- a/src/test/scala/changestream/helpers/Fixtures.scala
+++ b/src/test/scala/changestream/helpers/Fixtures.scala
@@ -97,7 +97,7 @@ object Fixtures {
   def mutation(
                 mutationType: String,
                 rowCount: Int = 1,
-                rowsInTransaction: Int = 1,
+                rowInTransaction: Int = 1,
                 sequenceNext: Long = 0,
                 database: String = "changestream_test",
                 tableName: String = "users",
@@ -145,28 +145,40 @@ object Fixtures {
     }).toArray
   }
 
-  def transactionInfo(rowCount: Int = 1) =
-    TransactionInfo(java.util.UUID.randomUUID().toString, rowCount)
-  def transactionInfoGtid(rowCount: Int = 1) =
-    TransactionInfo(s"${java.util.UUID.randomUUID().toString}:${Random.nextInt(100000)}", rowCount)
-  def transactionInfoEither(rowCount: Int = 1) = Random.nextInt(2) match { case 0 => transactionInfo(rowCount) case 1 => transactionInfoGtid(rowCount) }
+  def transactionInfo(rowInTransaction: Int = 1, isLastChangeInTransaction: Boolean = false) =
+    TransactionInfo(
+      java.util.UUID.randomUUID().toString,
+      rowInTransaction,
+      isLastChangeInTransaction
+    )
+  def transactionInfoGtid(rowInTransaction: Int = 1, isLastChangeInTransaction: Boolean = false) =
+    TransactionInfo(
+      s"${java.util.UUID.randomUUID().toString}:${Random.nextInt(100000)}",
+      rowInTransaction,
+      isLastChangeInTransaction
+    )
+  def transactionInfoEither(rowInTransaction: Int = 1, isLastChangeInTransaction: Boolean = false) = Random.nextInt(2) match {
+    case 0 => transactionInfo(rowInTransaction, isLastChangeInTransaction)
+    case 1 => transactionInfoGtid(rowInTransaction, isLastChangeInTransaction)
+  }
 
   def mutationWithInfo(
                         mutationType: String,
                         rowCount: Int = 1,
-                        rowsInTransaction: Int = 1,
+                        rowInTransaction: Int = 1,
                         transactionInfo: Boolean = true,
                         columns: Boolean = true,
                         sequenceNext: Long = 0,
                         database: String = "changestream_test",
                         tableName: String = "users",
-                        tableId: Int = 123
+                        tableId: Int = 123,
+                        isLastChangeInTransaction: Boolean = false
                       ): (MutationWithInfo, Seq[ListMap[String, Any]], Seq[ListMap[String, Any]]) = {
-    val (m, d, od) = mutation(mutationType, rowCount, rowsInTransaction, sequenceNext, database, tableName, tableId)
+    val (m, d, od) = mutation(mutationType, rowCount, rowInTransaction, sequenceNext, database, tableName, tableId)
     (MutationWithInfo(
       m,
       transaction = transactionInfo match {
-        case true => Some(transactionInfoEither(rowsInTransaction))
+        case true => Some(transactionInfoEither(rowInTransaction, isLastChangeInTransaction))
         case false => None
       },
       columns = columns match {


### PR DESCRIPTION
@alecjacobs @shirish-pampoorickal @bobby1190 @ahuth 

Solving the unbounded memory issue with very large transactions by only buffering one event so that the final mutation can be marked as the "last" one.

In this way, you know you don't have the full transaction if:
- you don't have the last mutation (i.e. a mutation with a transaction.last_mutation key)
- you have the last mutation, but the last mutation's row_count does not match the number of mutations that you've collected for the given transaction gtid