### PR TITLE
small bug in application conf

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -74,7 +74,7 @@ changestream {
     key = "yRVCuDlryZdWhSUDwLNugQ=="
 
     enabled = ${?ENCRYPTOR_ENABLED}
-    enabled = ${?ENCRYPTOR_ENCRYPT_FIELDS}
+    encrypt-fields = ${?ENCRYPTOR_ENCRYPT_FIELDS}
     timeout = ${?ENCRYPTOR_TIMEOUT}
     cipher = ${?ENCRYPTOR_CIPHER}
     key = ${?ENCRYPTOR_KEY}


### PR DESCRIPTION
`encryptor.encrypt-fields` should be set by the `ENCRYPTOR_ENCRYPT_FIELDS` env
And `encryptor.enabled` should be set by the `ENCRYPTED` boolean env

@racerpeter @bobby1190 