### PR TITLE
Fix deprecations & warnings

### DIFF
--- a/project/Testing.scala
+++ b/project/Testing.scala
@@ -44,7 +44,7 @@ object Testing {
 
   lazy val settings = testSettings ++ itSettings ++ benchSettings ++ Seq(
     libraryDependencies ++= Dependencies.testDependencies,
-    testAll <<= (test in Benchmark).dependsOn((test in IntegrationTest).dependsOn(test in Test))
+    testAll := (test in Benchmark).dependsOn((test in IntegrationTest).dependsOn(test in Test)).value
   )
 
   lazy val configs = Seq(

--- a/src/test/scala/changestream/ChangeStreamEventListenerSpec.scala
+++ b/src/test/scala/changestream/ChangeStreamEventListenerSpec.scala
@@ -1,5 +1,6 @@
 package changestream
 
+import scala.reflect.ClassTag
 import changestream.helpers.{Base, Config}
 import com.github.shyiko.mysql.binlog.event._
 import com.github.shyiko.mysql.binlog.event.EventType._
@@ -9,7 +10,7 @@ import changestream.events._
 import com.typesafe.config.ConfigFactory
 
 class ChangeStreamEventListenerSpec extends Base with Config {
-  def getTypedEvent[T](event: Event): Option[T] = ChangeStreamEventListener.getChangeEvent(event) match {
+  def getTypedEvent[T: ClassTag](event: Event): Option[T] = ChangeStreamEventListener.getChangeEvent(event) match {
     case Some(e: T) => Some(e)
     case _ => None
   }


### PR DESCRIPTION
Fix one deprecation and one warning.

First, the `<<=` operator is [deprecated as of SBT 0.12](http://www.scala-sbt.org/0.13/docs/Migrating-from-sbt-012x.html#Migrating+when+using+%2C++or).

Second, because of [type erasure](http://docs.scala-lang.org/overviews/reflection/typetags-manifests.html) we have to jump through a small hoop to be able to pattern match on a generic type at run-time.