### PR TITLE
Buffer changes on disk instead of in memory when sending data to S3.

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -100,8 +100,9 @@ changestream {
     sns.topic = "firehose"
 
     s3 {
-      // Make sure this directory is secure (trailing forward-slash is important)
-      buffer-temp-dir = "/tmp/"
+      // Make sure this directory is secure (trailing forward-slash is important).
+      // Defaults to empty string, which means use the default system temp dir
+      buffer-temp-dir = ""
       // The bucket name that is the destination for change events
       bucket = ""
       // Key prefix to use (e.g. production_db/)

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -100,6 +100,8 @@ changestream {
     sns.topic = "firehose"
 
     s3 {
+      // Make sure this directory is secure (trailing forward-slash is important)
+      buffer-temp-dir = "/tmp/"
       // The bucket name that is the destination for change events
       bucket = ""
       // Key prefix to use (e.g. production_db/)
@@ -109,6 +111,7 @@ changestream {
       // Maximum amount of time before flushing change buffer to S3
       flush-timeout = 300000 # ms
 
+      buffer-temp-dir = ${?AWS_S3_BUFFER_TEMP_DIR}
       bucket = ${?AWS_S3_BUCKET}
       key-prefix = ${?AWS_S3_KEY_PREFIX}
       batch-size = ${?AWS_S3_BATCH_SIZE}

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -101,7 +101,8 @@ changestream {
 
     s3 {
       // Make sure this directory is secure (trailing forward-slash is important).
-      // Defaults to empty string, which means use the default system temp dir
+      // Defaults to empty string, which means use the default system temp dir.
+      // The directory should exist and be writeable by the changestream user.
       buffer-temp-dir = ""
       // The bucket name that is the destination for change events
       bucket = ""

--- a/src/main/scala/changestream/actors/S3Actor.scala
+++ b/src/main/scala/changestream/actors/S3Actor.scala
@@ -101,17 +101,15 @@ class S3Actor(config: Config = ConfigFactory.load().getConfig("changestream")) e
   }
 
   override def preStart() = {
-    val testPutFuture = {
-      val file = new File(s"${BUFFER_TEMP_DIR}test.txt")
-      val bw = new BufferedWriter(new FileWriter(file))
-      bw.write("test")
-      bw.close()
+    val file = new File(s"${BUFFER_TEMP_DIR}test.txt")
+    val bw = new BufferedWriter(new FileWriter(file))
+    bw.write("test")
+    bw.close()
 
-      putFile(file).failed.map {
-        case exception:Throwable =>
-          log.error(s"Failed to create test object in S3 bucket ${BUCKET} at key ${KEY_PREFIX}test.txt: ${exception.getMessage}")
-          throw exception
-      }
+    val testPutFuture = putFile(file).failed.map {
+      case exception:Throwable =>
+        log.error(s"Failed to create test object in S3 bucket ${BUCKET} at key ${KEY_PREFIX}test.txt: ${exception.getMessage}")
+        throw exception
     }
 
     Await.result(testPutFuture, TIMEOUT milliseconds)

--- a/src/main/scala/changestream/actors/S3Actor.scala
+++ b/src/main/scala/changestream/actors/S3Actor.scala
@@ -30,7 +30,7 @@ class S3Actor(config: Config = ConfigFactory.load().getConfig("changestream")) e
   protected implicit val ec = context.dispatcher
 
   protected val BUFFER_TEMP_DIR = config.getString("aws.s3.buffer-temp-dir")
-  protected val bufferDirectory = new File(BUFFER_TEMP_DIR)
+  protected lazy val bufferDirectory = new File(BUFFER_TEMP_DIR)
   protected val BUCKET = config.getString("aws.s3.bucket")
   protected val KEY_PREFIX = config.getString("aws.s3.key-prefix") match {
     case s if s.endsWith("/") => s
@@ -61,7 +61,10 @@ class S3Actor(config: Config = ConfigFactory.load().getConfig("changestream")) e
   // End Mutable State!!
 
   // Wrap the Java IO
-  protected def getNextFile = File.createTempFile("-buffer", ".json", bufferDirectory)
+  protected def getNextFile = BUFFER_TEMP_DIR match {
+    case "" => File.createTempFile("-buffer", ".json")
+    case _ => File.createTempFile("-buffer", ".json", bufferDirectory)
+  }
   protected def getWriterForFile = {
     val streamWriter = new OutputStreamWriter(new FileOutputStream(bufferFile), StandardCharsets.UTF_8)
     new BufferedWriter(streamWriter)

--- a/src/main/scala/changestream/actors/S3Actor.scala
+++ b/src/main/scala/changestream/actors/S3Actor.scala
@@ -1,8 +1,8 @@
 package changestream.actors
 
-import java.io.ByteArrayInputStream
+import java.io._
+import java.nio.charset.StandardCharsets
 
-import scala.collection.mutable
 import scala.concurrent.duration._
 import scala.language.postfixOps
 import scala.util.{Failure, Success}
@@ -17,7 +17,6 @@ import com.typesafe.config.{Config, ConfigFactory}
 import org.joda.time.DateTime
 import org.slf4j.LoggerFactory
 
-import collection.JavaConverters._
 import scala.concurrent.{Await, Future}
 
 object S3Actor {
@@ -30,6 +29,8 @@ class S3Actor(config: Config = ConfigFactory.load().getConfig("changestream")) e
   protected val log = LoggerFactory.getLogger(getClass)
   protected implicit val ec = context.dispatcher
 
+  protected val BUFFER_TEMP_DIR = config.getString("aws.s3.buffer-temp-dir")
+  protected val bufferDirectory = new File(BUFFER_TEMP_DIR)
   protected val BUCKET = config.getString("aws.s3.bucket")
   protected val KEY_PREFIX = config.getString("aws.s3.key-prefix") match {
     case s if s.endsWith("/") => s
@@ -46,7 +47,24 @@ class S3Actor(config: Config = ConfigFactory.load().getConfig("changestream")) e
   }
   protected def cancelDelayedFlush = cancellableSchedule.foreach(_.cancel())
 
-  protected val messageBuffer = mutable.ArrayBuffer.empty[String]
+  // Mutable State!!
+  protected var currentBatchSize = 0
+  protected var bufferFile: File = getNextFile
+  protected var bufferWriter: BufferedWriter = getWriterForFile
+  // End Mutable State!!
+
+  // Wrap the Java IO
+  protected def getNextFile = File.createTempFile("buffer", ".json", bufferDirectory)
+  protected def getWriterForFile = {
+    val streamWriter = new OutputStreamWriter(new FileOutputStream(bufferFile), StandardCharsets.UTF_8)
+    new BufferedWriter(streamWriter)
+  }
+
+  protected def bufferMessage(message: String) = {
+    bufferWriter.write(message)
+    bufferWriter.newLine()
+    currentBatchSize += 1
+  }
 
   protected def getMetadata(length: Int, sseAlgorithm: String = "AES256") = {
     val metadata = new ObjectMetadata()
@@ -55,18 +73,23 @@ class S3Actor(config: Config = ConfigFactory.load().getConfig("changestream")) e
     metadata
   }
 
-  protected def getMessageBatch: String = {
-    val messages = messageBuffer.reduceLeft(_ + "\n" + _)
-    messageBuffer.clear()
+  protected def getMessageBatch = {
+    val batchFile = bufferFile
 
-    messages
+    bufferWriter.close()
+    currentBatchSize = 0
+    bufferFile = getNextFile
+    bufferWriter = getWriterForFile
+
+    batchFile
   }
 
-  protected def putString(key: String, contents: String): Future[PutObjectResult] = {
-    val inputBytes = contents.getBytes("UTF-8")
-    val inputStream = new ByteArrayInputStream(inputBytes)
-    val metadata = getMetadata(inputBytes.length)
-    client.putObject(new PutObjectRequest(BUCKET, s"${KEY_PREFIX}${key}", inputStream, metadata))
+  protected def putFile(file: File, key: String = ""): Future[PutObjectResult] = {
+    val objectKey = key match {
+      case "" => file.getName
+      case _ => key
+    }
+    client.putObject(new PutObjectRequest(BUCKET, s"${KEY_PREFIX}${objectKey}", file))
   }
 
   protected val client = new AmazonS3ScalaClient(
@@ -75,11 +98,17 @@ class S3Actor(config: Config = ConfigFactory.load().getConfig("changestream")) e
       withConnectionTimeout(TIMEOUT),
     Regions.fromName(config.getString("aws.region"))
   )
-  protected val testPutFuture = putString("test.txt", "test")
-  testPutFuture.failed.map {
-    case exception:Throwable =>
-      log.error(s"Failed to create test object in S3 bucket ${BUCKET} at key ${KEY_PREFIX}test.txt: ${exception.getMessage}")
-      throw exception
+  protected val testPutFuture = {
+    val file = new File(s"${BUFFER_TEMP_DIR}test.txt")
+    val bw = new BufferedWriter(new FileWriter(file))
+    bw.write("test")
+    bw.close()
+
+    putFile(file).failed.map {
+      case exception:Throwable =>
+        log.error(s"Failed to create test object in S3 bucket ${BUCKET} at key ${KEY_PREFIX}test.txt: ${exception.getMessage}")
+        throw exception
+    }
   }
 
   override def preStart() = {
@@ -97,8 +126,8 @@ class S3Actor(config: Config = ConfigFactory.load().getConfig("changestream")) e
 
       cancelDelayedFlush
 
-      messageBuffer += message
-      messageBuffer.size match {
+      bufferMessage(message)
+      currentBatchSize match {
         case BATCH_SIZE => flush(sender())
         case _ => setDelayedFlush(sender())
       }
@@ -108,21 +137,23 @@ class S3Actor(config: Config = ConfigFactory.load().getConfig("changestream")) e
   }
 
   protected def flush(origSender: ActorRef) = {
-    val messageCount = messageBuffer.length
-    log.debug(s"Flushing ${messageCount} messages to S3.")
+    log.debug(s"Flushing ${currentBatchSize} messages to S3.")
 
     val now = DateTime.now
     val datePrefix = f"${now.getYear}/${now.getMonthOfYear}%02d/${now.getDayOfMonth}%02d"
-    val key = s"${datePrefix}/${System.nanoTime}-${messageCount}.json"
+    val key = s"${datePrefix}/${System.nanoTime}-${currentBatchSize}.json"
+    val file = getMessageBatch
+    val request = putFile(file, key)
+
     val s3Url = s"${BUCKET}/${KEY_PREFIX}${key}"
-    val request = putString(key, getMessageBatch)
 
     request onComplete {
       case Success(result: PutObjectResult) =>
-        log.info(s"Successfully saved ${messageCount} messages to ${s3Url}.")
+        file.delete()
+        log.info(s"Successfully saved ${currentBatchSize} messages (${file.length} bytes) to ${s3Url}.")
         origSender ! akka.actor.Status.Success(s3Url)
       case Failure(exception) =>
-        log.error(s"Failed to save ${messageCount} messages to ${s3Url}: ${exception.getMessage}")
+        log.error(s"Failed to save ${currentBatchSize} messages from ${file.getName} (${file.length} bytes) to ${s3Url}: ${exception.getMessage}")
         throw exception
     }
   }

--- a/src/main/scala/changestream/actors/S3Actor.scala
+++ b/src/main/scala/changestream/actors/S3Actor.scala
@@ -106,7 +106,8 @@ class S3Actor(config: Config = ConfigFactory.load().getConfig("changestream")) e
     bw.write("test")
     bw.close()
 
-    val testPutFuture = putFile(file).failed.map {
+    val testPutFuture = putFile(file)
+    testPutFuture.failed.map {
       case exception:Throwable =>
         log.error(s"Failed to create test object in S3 bucket ${BUCKET} at key ${KEY_PREFIX}test.txt: ${exception.getMessage}")
         throw exception

--- a/src/test/scala/changestream/actors/JsonFormatterActorSpec.scala
+++ b/src/test/scala/changestream/actors/JsonFormatterActorSpec.scala
@@ -325,6 +325,15 @@ class JsonFormatterActorSpec extends Base with Config {
     }
   }
 
+  "The Json string, if it contains a newline character" should {
+    "have escaped newlines" in {
+      val obj = JsObject(ListMap("testMultiLine" -> JsString("""the value
+is multiline""")))
+
+      obj.compactPrint.shouldEqual("{\"testMultiLine\":\"the value\\nis multiline\"}")
+    }
+  }
+
   "When JsonFormatterActor receives many messages" should {
     "query row_count stats should be correct" in {
       val (mutation, rowData, oldRowData) = Fixtures.mutationWithInfo("update", 100, 100, true)


### PR DESCRIPTION
This PR makes two significant changes:

1. Immediately write new inbound changes to a file on disk, using the disk as a buffer instead of RAM.
2. Stream change data from disk to S3 rather than loading the entire file into memory.