### PR TITLE
Fix log output that could trigger ossec

### DIFF
--- a/src/main/scala/changestream/ChangeStreamEventListener.scala
+++ b/src/main/scala/changestream/ChangeStreamEventListener.scala
@@ -114,12 +114,18 @@ object ChangeStreamEventListener extends EventListener {
     blacklist.clear()
 
     if(config.hasPath("whitelist")) {
-      config.getString("whitelist").split(',').foreach(whitelist.add(_))
-      log.info("Using event whitelist: {}", whitelist)
+      config.getString("whitelist").split(',').foreach {
+        case table =>
+          log.info("Adding table to whitelist: {}", table)
+          whitelist.add(table)
+      }
     }
     else if(config.hasPath("blacklist")) {
-      config.getString("blacklist").split(',').foreach(blacklist.add(_))
-      log.info("Using event blacklist: {}", blacklist)
+      config.getString("blacklist").split(',').foreach {
+        case table =>
+          log.info("Adding table to blacklist: {}", table)
+          blacklist.add(table)
+      }
     }
 
     if(config.hasPath("position-saver.actor")) {


### PR DESCRIPTION
Having a long list of tables in the whitelist or blacklist results in log entries that trigger the default log length alert in OSSEC. Changing output to one table per log entry.