### PR TITLE
Fix OVERRIDE_POSITION feature, bump version to 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changestream Changelog
 
 
+## 0.4.0 (2018-12-18)
+
+- Added Kamon's stats collector to capture detailed stats on Changestream operations, including changes per table, change size, timing information, and messages in flight.
+- Automatically re-connect binlog client after `TimeoutException`, where previously only `IOException` was retried.
+- Log whitelist and blacklist configurations on multiple lines during startup to avoid triggering OSSEC's log length monitor.
+
+
 ## 0.3.1 (2018-08-06)
 
 - Fixed regression in SQL string length limiting

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val nextRelease = "0.3.1"
+val nextRelease = "0.4.0"
 val scalaVer = "2.11.11"
 
 lazy val projectInfo = Seq(

--- a/src/main/scala/changestream/ChangeStream.scala
+++ b/src/main/scala/changestream/ChangeStream.scala
@@ -51,10 +51,10 @@ object ChangeStream extends App {
   def clientId = client.getServerId
   def isConnected = client.isConnected
 
-  def getConnectedAndWait(startingPosition: Option[String] = None) = Await.result(getConnected(startingPosition), 60.seconds)
+  def getConnectedAndWait(startingPosition: Option[String]) = Await.result(getConnected(startingPosition), 60.seconds)
   def disconnectClient = client.disconnect()
 
-  def getConnected(startingPosition: Option[String] = None) = {
+  def getConnected(startingPosition: Option[String]) = {
     log.info("Starting changestream...")
 
     val getPositionFuture = startingPosition match {

--- a/src/main/scala/changestream/ChangeStream.scala
+++ b/src/main/scala/changestream/ChangeStream.scala
@@ -51,10 +51,10 @@ object ChangeStream extends App {
   def clientId = client.getServerId
   def isConnected = client.isConnected
 
-  def getConnectedAndWait(startingPosition: Option[String]) = Await.result(getConnected(startingPosition), 60.seconds)
+  def getConnectedAndWait(startingPosition: Option[String] = None) = Await.result(getConnected(startingPosition), 60.seconds)
   def disconnectClient = client.disconnect()
 
-  def getConnected(startingPosition: Option[String]) = {
+  def getConnected(startingPosition: Option[String] = None) = {
     log.info("Starting changestream...")
 
     val getPositionFuture = startingPosition match {

--- a/src/main/scala/changestream/ChangeStream.scala
+++ b/src/main/scala/changestream/ChangeStream.scala
@@ -18,7 +18,7 @@ object ChangeStream extends App {
   protected val mysqlHost = config.getString("mysql.host")
   protected val mysqlPort = config.getInt("mysql.port")
   protected val overridePosition = System.getenv("OVERRIDE_POSITION") match {
-    case position:String if position != null => Some(position) //scalastyle:ignore
+    case position:String if (position != null && position.length > 0) => Some(position) //scalastyle:ignore
     case _ => None
   }
   protected val client = new BinaryLogClient(

--- a/src/test/scala/changestream/ChangeStreamISpec.scala
+++ b/src/test/scala/changestream/ChangeStreamISpec.scala
@@ -272,13 +272,11 @@ class ChangeStreamISpec extends Database with Config {
       queryAndWait(INSERT)
 
       val overridePosition = getLiveBinLogPosition
-      System.setProperty("OVERRIDE_POSITION", overridePosition)
-      ConfigFactory.invalidateCaches()
 
       // this event should arrive first
       queryAndWait(UPDATE)
 
-      ChangeStream.getConnectedAndWait
+      ChangeStream.getConnectedAndWait(Some(overridePosition))
       ensureConnected
 
       // advance the live position to be "newer" than the override (should arrive second)
@@ -286,9 +284,6 @@ class ChangeStreamISpec extends Database with Config {
 
       expectMutation.mutation shouldBe a[Update]
       expectMutation.mutation shouldBe a[Delete]
-
-      System.setProperty("OVERRIDE_POSITION", "")
-      ConfigFactory.invalidateCaches()
     }
 
     "exit gracefully when a TERM signal is received" in {

--- a/src/test/scala/changestream/ChangeStreamISpec.scala
+++ b/src/test/scala/changestream/ChangeStreamISpec.scala
@@ -241,7 +241,7 @@ class ChangeStreamISpec extends Database with Config {
 
       queryAndWait(INSERT)
 
-      ChangeStream.getConnectedAndWait
+      ChangeStream.getConnectedAndWait(None)
       ensureConnected
 
       queryAndWait(UPDATE)
@@ -255,7 +255,7 @@ class ChangeStreamISpec extends Database with Config {
 
       queryAndWait(INSERT)
 
-      ChangeStream.getConnectedAndWait
+      ChangeStream.getConnectedAndWait(None)
       ensureConnected
 
       queryAndWait(UPDATE)
@@ -292,7 +292,7 @@ class ChangeStreamISpec extends Database with Config {
 
       val startingPosition = getStoredBinLogPosition
 
-      ChangeStream.getConnectedAndWait
+      ChangeStream.getConnectedAndWait(None)
       ensureConnected
 
       queryAndWait(INSERT) // should not persist immediately because of the max events = 2
@@ -310,7 +310,7 @@ class ChangeStreamISpec extends Database with Config {
 
       queryAndWait(UPDATE) // should not immediately persist
 
-      ChangeStream.getConnectedAndWait
+      ChangeStream.getConnectedAndWait(None)
       ensureConnected
 
       queryAndWait(DELETE) // should persist because it is the second event processed by the saver


### PR DESCRIPTION
Silly mistake-- in my zeal to have great spec coverage on the `OVERRIDE_POSITION` env, I made the mistake of implementing it as a Java property rather than a system environment variable.

Also bumping version to v0.4.0 and updating the changelog.